### PR TITLE
fix(e2e): Correct secure attribute for mock auth cookie

### DIFF
--- a/e2e/config/globalSetup.ts
+++ b/e2e/config/globalSetup.ts
@@ -74,7 +74,7 @@ async function globalSetup(config: FullConfig) {
         domain,
         path: '/',
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: baseURL.startsWith('https://'),
         sameSite: 'Lax',
         expires: Math.floor(Date.now() / 1000) + 86400, // 24 hours from now
       }


### PR DESCRIPTION
The E2E authentication tests were failing because the mock session cookie (`next-auth.session-token`) was being set with the `Secure` attribute even when tests were run over HTTP. This occurred when `NODE_ENV` was 'production' during the Playwright global setup phase. A `Secure` cookie is not sent by the browser over non-HTTPS connections, causing the tests to not find the cookie and fail.

This commit modifies `e2e/config/globalSetup.ts` to set the cookie's `secure` attribute based on whether the `baseURL` starts with 'https://'. For the E2E test environment, where `baseURL` is 'http://localhost:3000', the cookie will now correctly be set without the `Secure` flag, allowing it to be used and resolving the test failures.